### PR TITLE
Make Color Columns show up in tmux

### DIFF
--- a/colors/material-monokai.vim
+++ b/colors/material-monokai.vim
@@ -101,7 +101,7 @@ let s:changebg    = { "gui": "#5f5f87", "cterm": "60" }
 
 " editor
 call s:h("Normal",        { "fg": s:white,      "bg": s:black })
-call s:h("ColorColumn",   {                     "bg": s:lightblack })
+call s:h("ColorColumn",   {                     "bg": s:lightgrey })
 call s:h("CursorColumn",  {                     "bg": s:lightblack2 })
 call s:h("CursorLine",    {                     "bg": s:darkblack })
 call s:h("NonText",       { "fg": s:lightgrey })


### PR DESCRIPTION
- On line 104: Change "bg" from s:lightblack to s:lightgrey
  - This is because tmux interprets the background colors differently,
  making the background of vim the same as the background of
  the color column.