### PR TITLE
Add spellcheck highlighting

### DIFF
--- a/colors/material-monokai.vim
+++ b/colors/material-monokai.vim
@@ -120,6 +120,9 @@ call s:h("VertSplit",     { "fg": s:grey,       "bg": s:darkgrey })
 call s:h("LineNr",        { "fg": s:grey,       "bg": s:darkgrey })
 call s:h("CursorLineNr",  { "fg": s:aqua,       "bg": s:darkblack })
 call s:h("SignColumn",    {                     "bg": s:lightblack })
+call s:h("SpellBad",      { "fg": s:red,      "bg": s:yellow })
+call s:h("SpellCap",      {                                           "format": "underline"})
+call s:h("SpellLocal",    { "fg": s:yellow,                           "format": "underline"})
 
 " misc
 call s:h("SpecialKey",    { "fg": s:coolgrey })

--- a/colors/material-monokai.vim
+++ b/colors/material-monokai.vim
@@ -120,7 +120,7 @@ call s:h("VertSplit",     { "fg": s:grey,       "bg": s:darkgrey })
 call s:h("LineNr",        { "fg": s:grey,       "bg": s:darkgrey })
 call s:h("CursorLineNr",  { "fg": s:aqua,       "bg": s:darkblack })
 call s:h("SignColumn",    {                     "bg": s:lightblack })
-call s:h("SpellBad",      { "fg": s:red,      "bg": s:yellow })
+call s:h("SpellBad",      { "fg": s:red,        "bg": s:yellow })
 call s:h("SpellCap",      {                                           "format": "underline"})
 call s:h("SpellLocal",    { "fg": s:yellow,                           "format": "underline"})
 


### PR DESCRIPTION
- Add SpellBad highlighting with red foreground and yellow background
- Add SpellCap highlighting with underlined text
- Add SpellLocal highlighting with yellow, underlined foreground

See more information in `:h hl-SpellBad`, `:h hl-SpellCap`, and `:h hl-SpellLocal`